### PR TITLE
chore: Add invis/dither to the webring

### DIFF
--- a/webring.json
+++ b/webring.json
@@ -268,5 +268,10 @@
     "name": "reitardxd",
 	"gh": "ReitardXd",
 	"url": "https://reitardxd.me"
+  },
+  {
+    "name": "dither",
+    "gh": "DitherWither",
+    "url": "https://dither.dev"
   }
 ]


### PR DESCRIPTION
I use ditherwither on github but i'm invis on discord

I'll add myself the next/previous/random links to my webpage after the PR is through to avoid having a broken link, unless y'all prefer otherwise